### PR TITLE
Fix error in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^11.0.0"
       },
       "bin": {
-        "pkg-viz": "out/pkg-viz-cli.js"
+        "pkg-viz-cli": "out/pkg-viz-cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.5.8",


### PR DESCRIPTION
"bin" is "pkg-viz-cli" in package.json, but "pkg-viz" in package-lock.json